### PR TITLE
CDパイプラインの構築

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,4 +59,11 @@ jobs:
       # デプロイ
       - add_ssh_keys:
           fingerprints:
-            - "f4:6c:6e:0b:c1:39:e4:f9:cb:9b:01:d9:77:c4:a3:c7"
+            - "0b:4d:9f:51:4c:55:6c:b5:19:0c:bd:94:8d:f6:96:50"
+      - deploy:
+          name: Capistrano deploy
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "master" ]; then
+              exit 0
+            fi
+            bundle exec cap production deploy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,8 @@ jobs:
       - store_artifacts:
           path: /tmp/test-results
           destination: test-results
+
+      # デプロイ
+      - add_ssh_keys:
+          fingerprints:
+            - "f4:6c:6e:0b:c1:39:e4:f9:cb:9b:01:d9:77:c4:a3:c7"


### PR DESCRIPTION
## What
CircleCIを使用し、CDパイプラインを構築する。
.circleci/config.ymlを編集し、sshキーの登録、デプロイのコマンド等を記述。

## Why
CDパイプラインを構築し、githubへのpush時に自動でデプロイを行えるようにすることで、開発の効率を向上させる為。